### PR TITLE
clear child handles when cleanup node

### DIFF
--- a/rcljava/src/main/java/org/ros2/rcljava/RCLJava.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/RCLJava.java
@@ -80,26 +80,6 @@ public final class RCLJava {
 
   private static void cleanup() {
     for (Node node : nodes) {
-      for (Subscription subscription : node.getSubscriptions()) {
-        subscription.dispose();
-      }
-
-      for (Publisher publisher : node.getPublishers()) {
-        publisher.dispose();
-      }
-
-      for (Timer timer : node.getTimers()) {
-        timer.dispose();
-      }
-
-      for (Service service : node.getServices()) {
-        service.dispose();
-      }
-
-      for (Client client : node.getClients()) {
-        client.dispose();
-      }
-
       node.dispose();
     }
     nodes.clear();

--- a/rcljava/src/main/java/org/ros2/rcljava/node/NodeImpl.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/node/NodeImpl.java
@@ -24,6 +24,7 @@ import org.ros2.rcljava.consumers.Consumer;
 import org.ros2.rcljava.consumers.TriConsumer;
 import org.ros2.rcljava.contexts.Context;
 import org.ros2.rcljava.qos.QoSProfile;
+import org.ros2.rcljava.interfaces.Disposable;
 import org.ros2.rcljava.interfaces.MessageDefinition;
 import org.ros2.rcljava.interfaces.ServiceDefinition;
 import org.ros2.rcljava.parameters.ParameterType;
@@ -343,10 +344,26 @@ public class NodeImpl implements Node {
    */
   private static native void nativeDispose(long handle);
 
+  private <T extends Disposable> void cleanupDisposables(Collection<T> disposables) {
+    for (Disposable disposable : disposables) {
+      disposable.dispose();
+    }
+    disposables.clear();
+  }
+
+  private void cleanup() {
+    cleanupDisposables(subscriptions);
+    cleanupDisposables(publishers);
+    cleanupDisposables(timers);
+    cleanupDisposables(services);
+    cleanupDisposables(clients);
+  }
+
   /**
    * {@inheritDoc}
    */
   public final void dispose() {
+    cleanup();
     nativeDispose(this.handle);
     this.handle = 0;
   }

--- a/rcljava/src/test/java/org/ros2/rcljava/node/NodeTest.java
+++ b/rcljava/src/test/java/org/ros2/rcljava/node/NodeTest.java
@@ -209,8 +209,11 @@ public class NodeTest {
     std_msgs.msg.String value = future.get();
     assertEquals("Hello", value.getData());
 
+    node.removePublisher(publisher);
     publisher.dispose();
     assertEquals(0, publisher.getHandle());
+
+    node.removeSubscription(subscription);
     subscription.dispose();
     assertEquals(0, subscription.getHandle());
   }
@@ -251,8 +254,11 @@ public class NodeTest {
         float64Value2, int8Value2, uint8Value2, int16Value2, uint16Value2, int32Value2,
         uint32Value2, int64Value2, uint64Value2, stringValue2));
 
+    node.removePublisher(publisher);
     publisher.dispose();
     assertEquals(0, publisher.getHandle());
+
+    node.removeSubscription(subscription);
     subscription.dispose();
     assertEquals(0, subscription.getHandle());
   }
@@ -325,8 +331,11 @@ public class NodeTest {
     assertEquals(uint64Values, value.getUint64Values());
     assertEquals(stringValues, value.getStringValues());
 
+    node.removePublisher(publisher);
     publisher.dispose();
     assertEquals(0, publisher.getHandle());
+
+    node.removeSubscription(subscription);
     subscription.dispose();
     assertEquals(0, subscription.getHandle());
   }
@@ -371,8 +380,11 @@ public class NodeTest {
     assertEquals(4321, timeValue.getSec());
     assertEquals(7654, timeValue.getNanosec());
 
+    node.removePublisher(publisher);
     publisher.dispose();
     assertEquals(0, publisher.getHandle());
+
+    node.removeSubscription(subscription);
     subscription.dispose();
     assertEquals(0, subscription.getHandle());
   }
@@ -413,8 +425,11 @@ public class NodeTest {
         float64Value2, int8Value2, uint8Value2, int16Value2, uint16Value2, int32Value2,
         uint32Value2, int64Value2, uint64Value2, stringValue2));
 
+    node.removePublisher(publisher);
     publisher.dispose();
     assertEquals(0, publisher.getHandle());
+
+    node.removeSubscription(subscription);
     subscription.dispose();
     assertEquals(0, subscription.getHandle());
   }
@@ -487,8 +502,11 @@ public class NodeTest {
     assertEquals(uint64Values, value.getUint64Values());
     assertEquals(stringValues, value.getStringValues());
 
+    node.removePublisher(publisher);
     publisher.dispose();
     assertEquals(0, publisher.getHandle());
+
+    node.removeSubscription(subscription);
     subscription.dispose();
     assertEquals(0, subscription.getHandle());
   }
@@ -514,8 +532,11 @@ public class NodeTest {
     rcljava.msg.Empty value = future.get();
     assertNotEquals(null, value);
 
+    node.removePublisher(publisher);
     publisher.dispose();
     assertEquals(0, publisher.getHandle());
+
+    node.removeSubscription(subscription);
     subscription.dispose();
     assertEquals(0, subscription.getHandle());
   }
@@ -559,8 +580,11 @@ public class NodeTest {
         float64Value2, int8Value2, uint8Value2, int16Value2, uint16Value2, int32Value2,
         uint32Value2, int64Value2, uint64Value2, stringValue2));
 
+    node.removePublisher(publisher);
     publisher.dispose();
     assertEquals(0, publisher.getHandle());
+
+    node.removeSubscription(subscription);
     subscription.dispose();
     assertEquals(0, subscription.getHandle());
   }
@@ -594,8 +618,11 @@ public class NodeTest {
         float64Value1, int8Value1, uint8Value1, int16Value1, uint16Value1, int32Value1,
         uint32Value1, int64Value1, uint64Value1, stringValue1));
 
+    node.removePublisher(publisher);
     publisher.dispose();
     assertEquals(0, publisher.getHandle());
+
+    node.removeSubscription(subscription);
     subscription.dispose();
     assertEquals(0, subscription.getHandle());
   }
@@ -624,8 +651,11 @@ public class NodeTest {
         float64Value1, int8Value1, uint8Value1, int16Value1, uint16Value1, int32Value1,
         uint32Value1, int64Value1, uint64Value1, stringValue1));
 
+    node.removePublisher(publisher);
     publisher.dispose();
     assertEquals(0, publisher.getHandle());
+
+    node.removeSubscription(subscription);
     subscription.dispose();
     assertEquals(0, subscription.getHandle());
   }
@@ -679,8 +709,11 @@ public class NodeTest {
         float64Value2, int8Value2, uint8Value2, int16Value2, uint16Value2, int32Value2,
         uint32Value2, int64Value2, uint64Value2, stringValue2));
 
+    node.removePublisher(publisher);
     publisher.dispose();
     assertEquals(0, publisher.getHandle());
+
+    node.removeSubscription(subscription);
     subscription.dispose();
     assertEquals(0, subscription.getHandle());
   }
@@ -754,8 +787,11 @@ public class NodeTest {
     assertEquals(uint64Values, value.getUint64Values());
     assertEquals(stringValues, value.getStringValues());
 
+    node.removePublisher(publisher);
     publisher.dispose();
     assertEquals(0, publisher.getHandle());
+
+    node.removeSubscription(subscription);
     subscription.dispose();
     assertEquals(0, subscription.getHandle());
   }
@@ -783,8 +819,11 @@ public class NodeTest {
     rcljava.msg.UInt32 value = future.get();
     assertEquals(12345, value.getData());
 
+    node.removePublisher(publisher);
     publisher.dispose();
     assertEquals(0, publisher.getHandle());
+
+    node.removeSubscription(subscription);
     subscription.dispose();
     assertEquals(0, subscription.getHandle());
   }
@@ -848,10 +887,15 @@ public class NodeTest {
     rcljava.msg.UInt32 valueTwo = futureTwo.get();
     assertEquals(54321, valueTwo.getData());
 
+    node.removePublisher(publisher);
     publisher.dispose();
     assertEquals(0, publisher.getHandle());
+
+    node.removeSubscription(subscriptionOne);
     subscriptionOne.dispose();
     assertEquals(0, subscriptionOne.getHandle());
+
+    node.removeSubscription(subscriptionTwo);
     subscriptionTwo.dispose();
     assertEquals(0, subscriptionTwo.getHandle());
   }


### PR DESCRIPTION
clear child handle (publishers, subscribers, clients, services, timers) when cleanup node