### PR TITLE
(RclJava) Fix Node.testPubUInt32MultipleNodes() error

### DIFF
--- a/rcljava/src/test/java/org/ros2/rcljava/node/NodeTest.java
+++ b/rcljava/src/test/java/org/ros2/rcljava/node/NodeTest.java
@@ -837,7 +837,7 @@ public class NodeTest {
     executor.addNode(composableSubscriptionNodeOne);
     executor.addNode(composableSubscriptionNodeTwo);
 
-    while (RCLJava.ok() && !futureOne.isDone() && !futureTwo.isDone()) {
+    while (RCLJava.ok() && !(futureOne.isDone() && futureTwo.isDone())) {
       publisher.publish(msg);
       executor.spinSome();
     }


### PR DESCRIPTION
Currently, the while loop exit even if only one of futureOne and futureTwo done.
While loop should exit when both futureOne and futureTwo are done.